### PR TITLE
0.7.0 BREAKING UPDATE - renaming of commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Snyk Tags Tool
 
-Snyk Tags is a CLI tool with three purposes:
+Snyk Tags is a CLI tool with four purposes:
 
 - Help filter Snyk projects by product type by adding product tags across a Snyk Group or Organization - using ```snyk-tags tag```
-- Help filter Snyk projects by applying tags to a collection of projects (for example a git repo like **snyk-labs/nodejs-goof**) - using ```snyk-tags collection```
-- Help filter Snyk projects by applying attributes to a collection of projects (for example a git repo like **snyk-labs/nodejs-goof**) - using ```snyk-tags attribute```
+- Help filter Snyk projects by applying tags to a target import (for example a git repo like **snyk-labs/nodejs-goof**) - using ```snyk-tags target tag```
+- Help filter Snyk projects by applying attributes to a target import (for example a git repo like **snyk-labs/nodejs-goof**) - using ```snyk-tags target attributes```
+- Help filter Snyk projects by adding the GitHub Code Owner as a tag to target import (must be a GitHub repo in the form **snyk-labs/nodejs-goof**) - using ```snyk-tags target github```
 
 ### snyk-tags tag
 
@@ -14,25 +15,21 @@ Snyk Tags is a CLI tool with three purposes:
 
 You can also specify a custom tag for the specific project types.
 
-### snyk-tags collection
-
-```snyk-tags collection``` uses the Snyk Project Tag API to assign tags to all projects within a collection. A collection encompasses one or more projects in Snyk, for example:
-
-- **snyk-labs/nodejs-goof** is a collection from a git import
-- **library/httpd** is a collection from a container import
-- **/snyk-labs/nodejs-goof** is a collection from a CLI import
-
-You can also use ```snyk-tags collection``` to add your Github repository code owner as a tag to an imported repo with  ```snyk-tags collection github```
-
 [List all project types](#list-of-all-project-types)
 
-### snyk-tags attribute
+### snyk-tags target
 
-```snyk-tags attribute``` uses the Snyk Project Attribute API to assign attributes to all projects within a collection. A collection encompasses one or more projects in Snyk, for example:
+```snyk-tags target``` goes through a target (repo, container, CLI import) to assign tags, attributes and assign the GitHub code owner. Targets in snyk can be varied like:
 
-- **snyk-labs/nodejs-goof** is a collection from a git import
-- **library/httpd** is a collection from a container import
-- **/snyk-labs/nodejs-goof** is a collection from a CLI import
+- **snyk-labs/nodejs-goof** is the target from a git import
+- **library/httpd** is the target from a container import
+- **/snyk-labs/nodejs-goof** is the target from a CLI import
+
+You can use:
+
+- **```snyk-tags import tag```** to add tags to a target
+- **```snyk-tags import attributes```** to add attributes to a target
+- **```snyk-tags import github```** to add the GitHub Code Owner as a tag to a target. The GitHub repo must include the GitHub Organization e.g. **snyk-labs/nodejs-goof**
 
 [List all possible attributes](#list-of-all-attributes)
 
@@ -78,19 +75,19 @@ snyk-tags tag sca --scatype=npm --org-id=abc --token=abc
 I want to filter all projects within my ```snyk-labs/nodejs-goof``` repo by ```project:snyk```
 
 ``` bash
-snyk-tags collection tag --collectionname=snyk-labs/nodejs-goof --org-id=abc --token=abc --tagkey=project --tagvalue=snyk
+snyk-tags target tag --target=snyk-labs/nodejs-goof --org-id=abc --snyktkn=abc --tagkey=project --tagvalue=snyk
 ```
 
 I want to add attributes to all projects within my ```snyk-labs/python-goof``` repo. The attributes are ```critical, production, backend```
 
 ``` bash
-snyk-tags attribute collection  --collectionname=snyk-labs/python-goof --org-id=abc --token=abc --criticality=critical --environment=backend --lifecycle=production
+snyk-tags import attributes  --target=snyk-labs/python-goof --org-id=abc --snytkn=abc --criticality=critical --environment=backend --lifecycle=production
 ```
 
 I want mark with the repo owner all projects of the repo ```snyk-labs/nodejs-goof``` so I can filter by owner e.g.```Owner:EricFernandezSnyk```
 
 ``` bash
-snyk-tags collection github --reponame=snyk-labs/nodejs-goof --org-id=abc --snyktoken=abc --githubtoken=abc
+snyk-tags import github --target=snyk-labs/nodejs-goof --org-id=abc --snyktkn=abc --githubtkn=abc
 ```
 
 ## Types of projects and attributes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "snyk-tags"
-version = "0.6.0"
+version = "0.7.0"
 description = "Tool designed to add tags in bulk to Snyk projects"
 authors = ["EricFernandezSnyk <eric.fernandez@snyk.io>"]
 license = "MIT"

--- a/snyk_tags/__init__.py
+++ b/snyk_tags/__init__.py
@@ -1,7 +1,7 @@
 # snyk_tags/__init__.py
 
 __app_name__ = "snyk_tags"
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 
 from logging import ERROR
 from sre_constants import SUCCESS

--- a/snyk_tags/attribute.py
+++ b/snyk_tags/attribute.py
@@ -21,7 +21,7 @@ def create_client(token: str) -> httpx.Client:
         base_url="https://snyk.io/api/v1", headers={"Authorization": f"token {token}", 'Content-Type': 'application/json'} 
     )
 
-# Apply tags to a specific project
+# Apply attributes to a specific project
 def apply_attributes_to_project(
     client: httpx.Client, org_id: str, project_id: str, criticality: list, environment: list, lifecycle: list, project_name: str
 ) -> tuple:
@@ -46,7 +46,7 @@ def apply_attributes_to_project(
     
     return req.status_code, req.json()
 
-#
+# Apply attributes to projects within a collection
 def apply_attributes_to_projects(token: str, org_ids: list, name: str, criticality: list, environment: list, lifecycle: list) -> None:
     with create_client(token=token) as client:
         for org_id in org_ids:
@@ -56,36 +56,3 @@ def apply_attributes_to_projects(token: str, org_ids: list, name: str, criticali
                     apply_attributes_to_project(
                             client=client, org_id=org_id, project_id=project["id"], criticality=criticality, environment=environment, lifecycle=lifecycle, project_name=project["name"]
                         )
-
-# Coloured variables for output
-repoexample = typer.style("'snyk-labs/nodejs-goof'", bold=True, fg=typer.colors.MAGENTA)
-crit = typer.style("critical, high, medium, low", bold=True, fg=typer.colors.MAGENTA)
-enviro = typer.style("frontend, backend, internal, 	external, mobile, saas, onprem, hosted, distributed", bold=True, fg=typer.colors.MAGENTA)
-life = typer.style("production, development, sandbox", bold=True, fg=typer.colors.MAGENTA)
-
-# Collection command to apply the attributes to the collection
-@app.command(help=f"Apply attributes to a project collection\n\n Use the name you see in the collection as the name: name={repoexample} to set the attributes for everything under that repo, container or CLI import")
-def collection(org_id: str = typer.Option(
-            ..., # Default value of comamand
-            envvar=["ORG_ID"],
-            help="Specify the Organization ID where you want to apply the attributes"
-        ),  token: str = typer.Option(
-            ..., # Default value of comamand
-            help="SNYK API token",
-            envvar=["SNYK_TOKEN"]
-        ),  collectionName: str = typer.Option(
-            ..., # Default value of comamand
-            help=f"Name of the project collection, for example {repoexample}"
-        ),  criticality: str = typer.Option(
-            ..., # Default value of comamand
-            help=f"Criticality attribute: {crit}"
-        ),  environment: str = typer.Option(
-            ..., # Default value of comamand
-            help=f"Environment attribute: {enviro}"
-        ),  lifecycle: str = typer.Option(
-            ..., # Default value of comamand
-            help=f"Lifecycle attribute: {life}"
-        )
-    ):
-    typer.secho(f"\nAdding the attributes {criticality}, {environment} and {lifecycle} to projects within {collectionName} for easy filtering via the UI", bold=True, fg=typer.colors.MAGENTA)
-    apply_attributes_to_projects(token,[org_id], collectionName, [criticality], [environment], [lifecycle])

--- a/snyk_tags/collection.py
+++ b/snyk_tags/collection.py
@@ -5,7 +5,7 @@ import httpx
 import typer
 from github import Github
 
-from snyk_tags import __app_name__, __version__
+from snyk_tags import __app_name__, __version__, attribute
 
 logging.basicConfig(
     level=logging.INFO,
@@ -71,11 +71,11 @@ def tag(org_id: str = typer.Option(
             ..., # Default value of comamand
             envvar=["ORG_ID"],
             help="Specify the Organization ID where you want to apply the tag"
-        ),  token: str = typer.Option(
+        ),  snyktkn: str = typer.Option(
             ..., # Default value of comamand
             help="Snyk API token with org admin access",
             envvar=["SNYK_TOKEN"]
-        ),  collectionName: str = typer.Option(
+        ),  target: str = typer.Option(
             ..., # Default value of comamand
             help=f"Name of the project collection, for example {repoexample}"
         ),  tagKey: str = typer.Option(
@@ -86,26 +86,60 @@ def tag(org_id: str = typer.Option(
             help="Tag value: value of the tag"
         )
     ):
-    typer.secho(f"\nAdding the tag key {tagKey} and tag value {tagValue} to projects within {collectionName} for easy filtering via the UI", bold=True)
-    apply_tags_to_projects(token,[org_id], collectionName, tagValue, tagKey)
+    typer.secho(f"\nAdding the tag key {tagKey} and tag value {tagValue} to projects within {target} for easy filtering via the UI", bold=True)
+    apply_tags_to_projects(snyktkn,[org_id], target, tagValue, tagKey)
 
+# GitHub Code Owner Tagging
 @app.command(help=f"Add the GitHub code owner as a tag to the specified repo in Snyk, for example {repoexample}")
 def github(org_id: str = typer.Option(
             ..., # Default value of comamand
             envvar=["ORG_ID"],
             help="Specify the Organization ID where you want to apply the tag"
-        ),  snyktoken: str = typer.Option(
+        ),  snyktkn: str = typer.Option(
             ..., # Default value of comamand
             help="Snyk API token with org admin access",
             envvar=["SNYK_TOKEN"]
-        ),  repoName: str = typer.Option(
+        ),  target: str = typer.Option(
             ..., # Default value of comamand
             help=f"Name of the repo, for example {repoexample}"
-        ),  githubtoken: str = typer.Option(
+        ),  githubtkn: str = typer.Option(
             ..., # Default value of comamand
             help="GitHub Personal Access Token with access to the repository",
             envvar=["GITHUB_TOKEN"]
         )
     ):
-    typer.secho(f"\nAdding the Owner tag to projects within {repoName} for easy filtering via the UI", bold=True)
-    apply_github_owner_to_repo(snyktoken,[org_id], repoName, githubtoken)
+    typer.secho(f"\nAdding the Owner tag to projects within {target} for easy filtering via the UI", bold=True)
+    apply_github_owner_to_repo(snyktkn,[org_id], target, githubtkn)
+
+# Coloured variables for output
+repoexample = typer.style("'snyk-labs/nodejs-goof'", bold=True, fg=typer.colors.MAGENTA)
+crit = typer.style("critical, high, medium, low", bold=True, fg=typer.colors.MAGENTA)
+enviro = typer.style("frontend, backend, internal, 	external, mobile, saas, onprem, hosted, distributed", bold=True, fg=typer.colors.MAGENTA)
+life = typer.style("production, development, sandbox", bold=True, fg=typer.colors.MAGENTA)
+
+# Collection command to apply the attributes to the collection
+@app.command(help=f"Apply attributes to a target, for example {repoexample}")
+def attributes(org_id: str = typer.Option(
+            ..., # Default value of comamand
+            envvar=["ORG_ID"],
+            help="Specify the Organization ID where you want to apply the attributes"
+        ),  snyktkn: str = typer.Option(
+            ..., # Default value of comamand
+            help="Snyk API token with org admin access",
+            envvar=["SNYK_TOKEN"]
+        ),  target: str = typer.Option(
+            ..., # Default value of comamand
+            help=f"Name of the project collection, for example {repoexample}"
+        ),  criticality: str = typer.Option(
+            ..., # Default value of comamand
+            help=f"Criticality attribute: {crit}"
+        ),  environment: str = typer.Option(
+            ..., # Default value of comamand
+            help=f"Environment attribute: {enviro}"
+        ),  lifecycle: str = typer.Option(
+            ..., # Default value of comamand
+            help=f"Lifecycle attribute: {life}"
+        )
+    ):
+    typer.secho(f"\nAdding the attributes {criticality}, {environment} and {lifecycle} to projects within {target} for easy filtering via the UI", bold=True, fg=typer.colors.MAGENTA)
+    attribute.apply_attributes_to_projects(snyktkn,[org_id], target, [criticality], [environment], [lifecycle])

--- a/snyk_tags/list.py
+++ b/snyk_tags/list.py
@@ -8,41 +8,40 @@ from snyk_tags import __app_name__, __version__
 app = typer.Typer()
 console = Console()
 '''
-List all the different project types for Snyk Products and attribute types
+List all the different project types and attribute types
 '''
 
-# SAST Command
-@app.command(help="List all Snyk Code project types")
-def sast():
-    snykcmd = typer.style("snyk-tags apply sast", bold=True, fg=typer.colors.MAGENTA)
-    typer.echo(f"These are all the Snyk Code project types you can use with {snykcmd}")
-    typer.echo("\n sast")
+# List all project types command
+@app.command(help="List all Snyk project types")
+def types():
+    snykcmd = typer.style("snyk-tags target tag or snyk-tags tag custom", bold=True, fg=typer.colors.MAGENTA)
+    typer.echo(f"These are all the attribute types you can apply with {snykcmd}")
+    table = Table("Snyk IaC", "Snyk Open Source", "Snyk Container", "Snyk Code")
+    table.add_row("terraformconfig", "maven", "dockerfile", "sast")
+    table.add_row("dockerfile", "npm", "apk", "")
+    table.add_row("terraformplan", "nuget", "deb", "")
+    table.add_row("k8sconfig", "gradle", "rpm", "")
+    table.add_row("helmconfig", "pip", "linux", "")
+    table.add_row("cloudformationconfig", "yarn", "", "")
+    table.add_row("armconfig", "gomodules", "", "")
+    table.add_row("", "rubygems", "", "")
+    table.add_row("", "composer", "", "")
+    table.add_row("", "sbt", "", "")
+    table.add_row("", "golangdep", "", "")
+    table.add_row("", "cocoapods", "", "")
+    table.add_row("", "poetry", "", "")
+    table.add_row("", "govendor", "", "")
+    table.add_row("", "cpp", "", "")
+    table.add_row("", "yarn-workspace", "", "")
+    table.add_row("", "hex", "", "")
+    table.add_row("", "paket", "", "")
+    table.add_row("", "golang", "", "")
+    console.print(table)
 
-# Container Command
-@app.command(help="List all Snyk Container project types")
-def container():
-    snykcmd = typer.style("snyk-tags apply container", bold=True, fg=typer.colors.MAGENTA)
-    typer.echo(f"These are all the Snyk Container project types you can use with {snykcmd}")
-    typer.echo("\n dockerfile\n apk\n deb\n rpm\n linux")
-
-# IaC Command
-@app.command(help="List all Snyk IaC project types")
-def iac():
-    snykcmd = typer.style("snyk-tags apply iac", bold=True, fg=typer.colors.MAGENTA)
-    typer.echo(f"These are all the Snyk IaC project types you can use with {snykcmd}")
-    typer.echo("\n terraformconfig\n terraformplan\n k8sconfig\n helmconfig\n cloudformationconfig\n armconfig")
-
-# SCA Command
-@app.command(help="List all Snyk Open Source project types")
-def sca():
-    snykcmd = typer.style("snyk-tags apply sca", bold=True, fg=typer.colors.MAGENTA)
-    typer.echo(f"These are all the Snyk Open Source project types you can use with {snykcmd}")
-    typer.echo("\n maven\n npm\n nuget\n gradle\n pip\n yarn\n gomodules\n rubygems\n composer\n sbt\n golangdep\n cocoapods\n poetry\n govendor\n cpp\n yarn-workspace\n hex\n paket\n golang")
-
-# IaC Command
-@app.command(help="List all attribute types")
+# List Attributes Command
+@app.command(help="List all Snyk attribute")
 def attributes():
-    snykcmd = typer.style("snyk-tags attribute collection", bold=True, fg=typer.colors.MAGENTA)
+    snykcmd = typer.style("snyk-tags target attributes", bold=True, fg=typer.colors.MAGENTA)
     typer.echo(f"These are all the attribute types you can apply with {snykcmd}")
     table = Table("Criticality", "Environment", "Lifecycle")
     table.add_row("critical", "frontend", "production")

--- a/snyk_tags/tag.py
+++ b/snyk_tags/tag.py
@@ -77,9 +77,9 @@ def sast(group_id: str = typer.Option(
             "", # Default value of comamand
             envvar=["ORG_ID"],
             help="Specify one Organization ID to only apply the tag to one organization"
-        ), token: str = typer.Option(
+        ), snyktkn: str = typer.Option(
             ..., # Default value of comamand
-            help="SNYK API token",
+            help="Snyk API token with org admin access",
             envvar=["SNYK_TOKEN"]
         ),  sastType: str = typer.Option(
             "", # Default value of comamand
@@ -93,24 +93,24 @@ def sast(group_id: str = typer.Option(
         if sastType == '' or None:
             sastType = ["sast"]
             typer.secho(f"\nAdding the Code tag to {sastType} projects in Snyk for easy filtering via the UI", bold=True)
-            org_ids = get_org_ids(token, group_id)
-            apply_tags_to_projects(token, org_ids, sastType, tag='Code', key='Product')
+            org_ids = get_org_ids(snyktkn, group_id)
+            apply_tags_to_projects(snyktkn, org_ids, sastType, tag='Code', key='Product')
         else:
             type.append(sastType)
             typer.secho(f"\nAdding the Code tag to {sastType} projects in Snyk for easy filtering via the UI", bold=True)
-            org_ids = get_org_ids(token, group_id)
-            apply_tags_to_projects(token, org_ids, type, tag='Code', key='Product')
+            org_ids = get_org_ids(snyktkn, group_id)
+            apply_tags_to_projects(snyktkn, org_ids, type, tag='Code', key='Product')
     else:
         if sastType == '' or None:
             sastType = ["sast"]
             typer.secho(f"\nAdding the Code tag to {sastType} projects in Snyk for easy filtering via the UI", bold=True)
             org.append(org_id)
-            apply_tags_to_projects(token, org, sastType, tag='Code', key='Product')
+            apply_tags_to_projects(snyktkn, org, sastType, tag='Code', key='Product')
         else:
             type.append(sastType)
             typer.secho(f"\nAdding the Code tag to {sastType} projects in Snyk for easy filtering via the UI", bold=True)
             org.append(org_id)
-            apply_tags_to_projects(token, org_ids, type, tag='Code', key='Product')
+            apply_tags_to_projects(snyktkn, org_ids, type, tag='Code', key='Product')
 
 
 
@@ -125,9 +125,9 @@ def iac(group_id: str = typer.Option(
             "", # Default value of comamand
             envvar=["ORG_ID"],
             help="Specify one Organization ID to only apply the tag to one organization"
-        ), token: str = typer.Option(
+        ), snyktkn: str = typer.Option(
             ..., # Default value of comamand
-            help="SNYK API token",
+            help="Snyk API token with org admin access",
             envvar=["SNYK_TOKEN"]
         ),  iacType: str = typer.Option(
             "", # Default value of comamand
@@ -141,24 +141,24 @@ def iac(group_id: str = typer.Option(
         if iacType == '' or None:
             iacType=["terraformconfig", "terraformplan", "k8sconfig", "helmconfig", "cloudformationconfig", "armconfig"]
             typer.secho(f"\nAdding the IaC tag to {iacType} projects in Snyk for easy filtering via the UI", bold=True)
-            org_ids = get_org_ids(token, group_id)
-            apply_tags_to_projects(token, org_ids, iacType, tag='IaC', key='Product')
+            org_ids = get_org_ids(snyktkn, group_id)
+            apply_tags_to_projects(snyktkn, org_ids, iacType, tag='IaC', key='Product')
         else:
             type.append(iacType)
             typer.secho(f"\nAdding the IaC tag to {iacType} projects in Snyk for easy filtering via the UI", bold=True)
-            org_ids = get_org_ids(token, group_id)
-            apply_tags_to_projects(token, org, type, tag='IaC', key='Product')
+            org_ids = get_org_ids(snyktkn, group_id)
+            apply_tags_to_projects(snyktkn, org, type, tag='IaC', key='Product')
     else:
         if iacType == '' or None:
             iacType=["terraformconfig", "terraformplan", "k8sconfig", "helmconfig", "cloudformationconfig", "armconfig"]
             typer.secho(f"\nAdding the IaC tag to {iacType} projects in Snyk for easy filtering via the UI", bold=True)
             org.append(org_id)
-            apply_tags_to_projects(token, org, iacType, tag='IaC', key='Product')
+            apply_tags_to_projects(snyktkn, org, iacType, tag='IaC', key='Product')
         else:
             type.append(iacType)
             typer.secho(f"\nAdding the IaC tag to {iacType} projects in Snyk for easy filtering via the UI", bold=True)
             org.append(org_id)
-            apply_tags_to_projects(token, org, type, tag='IaC', key='Product')
+            apply_tags_to_projects(snyktkn, org, type, tag='IaC', key='Product')
 
 
 
@@ -173,9 +173,9 @@ def sca(group_id: str = typer.Option(
             "", # Default value of comamand,
             envvar=["ORG_ID"],
             help="Specify one Organization ID to only apply the tag to one organization"
-        ),  token: str = typer.Option(
+        ),  snyktkn: str = typer.Option(
             ..., # Default value of comamand
-            help="SNYK API token",
+            help="Snyk API token with org admin access",
             envvar=["SNYK_TOKEN"]
         ),  scaType: str = typer.Option(
             "", # Default value of comamand
@@ -189,24 +189,24 @@ def sca(group_id: str = typer.Option(
         if scaType == '' or None:
             scaType = ["maven","npm","nuget", "gradle", "pip", "yarn", "gomodules", "rubygems", "composer", "sbt", "golangdep", "cocoapods", "poetry", "govendor", "cpp", "yarn-workspace", "hex", "paket", "golang"]
             typer.secho(f"\nAdding the Open Source tag to {scaType} projects in Snyk for easy filtering via the UI", bold=True)
-            org_ids = get_org_ids(token, group_id)
-            apply_tags_to_projects(token, org_ids, scaType, tag='Open Source', key='Product')
+            org_ids = get_org_ids(snyktkn, group_id)
+            apply_tags_to_projects(snyktkn, org_ids, scaType, tag='Open Source', key='Product')
         else:
             type.append(scaType)
             typer.secho(f"\nAdding the Open Source tag to {scaType} projects in Snyk for easy filtering via the UI", bold=True)
-            org_ids = get_org_ids(token, group_id)
-            apply_tags_to_projects(token, org_ids, type, tag='Open Source', key='Product')
+            org_ids = get_org_ids(snyktkn, group_id)
+            apply_tags_to_projects(snyktkn, org_ids, type, tag='Open Source', key='Product')
     else:
         if scaType == '' or None:
             scaType = ["maven","npm","nuget", "gradle", "pip", "yarn", "gomodules", "rubygems", "composer", "sbt", "golangdep", "cocoapods", "poetry", "govendor", "cpp", "yarn-workspace", "hex", "paket", "golang"]
             typer.secho(f"\nAdding the Open Source tag to {scaType} projects in Snyk for easy filtering via the UI", bold=True)
             org.append(org_id)
-            apply_tags_to_projects(token, org, scaType, tag='Open Source', key='Product')
+            apply_tags_to_projects(snyktkn, org, scaType, tag='Open Source', key='Product')
         else:
             type.append(scaType)
             typer.secho(f"\nAdding the Open Source tag to {scaType} projects in Snyk for easy filtering via the UI", bold=True)
             org.append(org_id)
-            apply_tags_to_projects(token, org, type, tag='Open Source', key='Product')
+            apply_tags_to_projects(snyktkn, org, type, tag='Open Source', key='Product')
 
 
 
@@ -221,9 +221,9 @@ def container(group_id: str = typer.Option(
             "", # Default value of comamand
             envvar=["ORG_ID"],
             help="Specify one Organization ID to only apply the tag to one organization"
-        ),  token: str = typer.Option(
+        ),  snyktkn: str = typer.Option(
             ..., # Default value of comamand
-            help="SNYK API token",
+            help="Snyk API token with org admin access",
             envvar=["SNYK_TOKEN"]
         ),  containerType: str = typer.Option(
             "", # Default value of comamand
@@ -237,24 +237,24 @@ def container(group_id: str = typer.Option(
         if containerType == '' or None:
             containerType= ["dockerfile", "apk", "deb", "rpm", "linux"]
             typer.secho(f"\nAdding the Container tag to {containerType} projects in Snyk for easy filtering via the UI", bold=True)
-            org_ids = get_org_ids(token, group_id)
-            apply_tags_to_projects(token, org_ids, containerType, tag='Container', key='Product')
+            org_ids = get_org_ids(snyktkn, group_id)
+            apply_tags_to_projects(snyktkn, org_ids, containerType, tag='Container', key='Product')
         else:
             type.append(containerType)
             typer.secho(f"\nAdding the Container tag to {containerType} projects in Snyk for easy filtering via the UI", bold=True)
-            org_ids = get_org_ids(token, group_id)
-            apply_tags_to_projects(token, org_ids, type, tag='Container', key='Product')
+            org_ids = get_org_ids(snyktkn, group_id)
+            apply_tags_to_projects(snyktkn, org_ids, type, tag='Container', key='Product')
     else:
         if containerType == '' or None:
             containerType= ["dockerfile", "apk", "deb", "rpm", "linux"]
             typer.secho(f"\nAdding the Container tag to {containerType} projects in Snyk for easy filtering via the UI", bold=True)
             org.append(org_id)
-            apply_tags_to_projects(token, org, containerType, tag='Container', key='Product')
+            apply_tags_to_projects(snyktkn, org, containerType, tag='Container', key='Product')
         else:
             type.append(containerType)
             typer.secho(f"\nAdding the Container tag to {containerType} projects in Snyk for easy filtering via the UI", bold=True)
             org.append(org_id)
-            apply_tags_to_projects(token, org, type, tag='Container', key='Product')
+            apply_tags_to_projects(snyktkn, org, type, tag='Container', key='Product')
 
 # Custom Command
 @app.command(help="Apply custom tags to the preferred project type")
@@ -266,9 +266,9 @@ def custom(group_id: str = typer.Option(
             "", # Default value of comamand
             envvar=["ORG_ID"],
             help="Specify one Organization ID to only apply the tag to one organization"
-        ),  token: str = typer.Option(
+        ),  snyktkn: str = typer.Option(
             ..., # Default value of comamand
-            help="SNYK API token",
+            help="Snyk API token with org admin access",
             envvar=["SNYK_TOKEN"]
         ),  projectType: str = typer.Option(
             ..., # Default value of comamand
@@ -287,9 +287,9 @@ def custom(group_id: str = typer.Option(
     type =[]
     type.append(projectType)
     if org_id == '' or None:
-        org_ids = get_org_ids(token, group_id)
-        apply_tags_to_projects(token, org_ids, type, tagValue, tagKey)
+        org_ids = get_org_ids(snyktkn, group_id)
+        apply_tags_to_projects(snyktkn, org_ids, type, tagValue, tagKey)
     else:
         org.append(org_id)
-        apply_tags_to_projects(token, org, type, tagValue, tagKey)
+        apply_tags_to_projects(snyktkn, org, type, tagValue, tagKey)
 

--- a/snyk_tags/tags.py
+++ b/snyk_tags/tags.py
@@ -7,19 +7,17 @@ from snyk_tags import __app_name__, __version__, list, collection, tag, attribut
 
 snyk = typer.style("snyk-tags", bold=True)
 snykcmd = typer.style("snyk-tags tag --help", bold=True, fg=typer.colors.MAGENTA)
-snykcmd2 = typer.style("snyk-tags attribute --help", bold=True, fg=typer.colors.MAGENTA)
-snykcmd3 = typer.style("snyk-tags collection --help", bold=True, fg=typer.colors.MAGENTA)
+snykcmd2 = typer.style("snyk-tags target --help", bold=True, fg=typer.colors.MAGENTA)
+snykcmd3 = typer.style("snyk-tags list --help", bold=True, fg=typer.colors.MAGENTA)
 
 app = typer.Typer(
-    help=f"{snyk} helps you filter Snyk projects by adding product tags and attributes to projects per product or collection of projects\n\n To start using it try running:\n\n - {snykcmd} \n\n - {snykcmd2}  \n\n - {snykcmd3}",
+    help=f"{snyk} helps you filter Snyk projects by adding product tags and attributes to projects per product or target of projects\n\n To start using it try running:\n\n - {snykcmd} \n\n - {snykcmd2}  \n\n - {snykcmd3}",
     add_completion=False,
     no_args_is_help=True
     )
-app.add_typer(tag.app, name="tag", help="Apply product/custom tags based on project type, select which tag to apply")
-app.add_typer(list.app, name="list", help="List all project types of a Snyk product and all attribute types")
-app.add_typer(collection.app, name="collection", help="Apply custom tags to all projects within a collection e.g Git repo")
-app.add_typer(attribute.app, name="attribute", help="Apply attributes to all projects within a collection e.g Git repo")
-
+app.add_typer(tag.app, name="tag", help="Apply product/custom tags based on the product or project type")
+app.add_typer(list.app, name="list", help="List all Snyk project types and all attribute types")
+app.add_typer(collection.app, name="target", help="Apply custom tags and attributes to all projects within a target e.g Git repo")
 
 def main():
     return True


### PR DESCRIPTION
Rename --token option to --snyktkn for clarity
Rename collection command to target for clarity - in the V3 API the collections are called target
Move attributes capability to target for clarity (only can be applied to a target)
Rename --githubtoken option to --githubtkn